### PR TITLE
 Show user-friendly errors when kanmon has been opened

### DIFF
--- a/lib/kanmon/cli.rb
+++ b/lib/kanmon/cli.rb
@@ -11,6 +11,9 @@ module Kanmon
     def open
       @sg.open
       puts "Success!!"
+    rescue Yao::Conflict => e
+      puts "Is not it already opened?" if e.message.include?("Security group rule already exists.")
+      puts e
     end
 
     desc "close", "Commands about delete rules from SecurityGroup"


### PR DESCRIPTION
うっかり2重にopenしちゃうと
ちょっとドキッとしちゃうのでいい感じにエラーを表示するようにしました。

```
$ kanmon open
Is not it already opened?
Security group rule already exists. Rule id is 11122233-4444-5555-6666-777788889999.
```