### PR TITLE
options pass to invoked command

### DIFF
--- a/lib/kanmon/cli.rb
+++ b/lib/kanmon/cli.rb
@@ -38,7 +38,7 @@ module Kanmon
 
     desc "ssh HOSTNAME", "Commands about exec ssh"
     def ssh(*args)
-      invoke CLI, [:exec], args.unshift("ssh")
+      invoke :exec, args.unshift("ssh")
     end
 
     desc "exec COMMAND", "Commands about open, exec command, close"


### PR DESCRIPTION
Options aren't pass to invoked command when exec ssh command.
I change invoke method's first argument to comamnd name.