### PR TITLE
bugfix: show version.

### DIFF
--- a/lib/kanmon/cli.rb
+++ b/lib/kanmon/cli.rb
@@ -1,6 +1,7 @@
 require "thor"
 require "shellwords"
 
+require "kanmon/version"
 require "kanmon/securitygroup"
 require "kanmon/server"
 


### PR DESCRIPTION
version subcommand fails.

```sh
$ kanmon version
Traceback (most recent call last):
        8: from /Users/sugy/.rbenv/versions/2.5.1/bin/kanmon:23:in `<main>'
        7: from /Users/sugy/.rbenv/versions/2.5.1/bin/kanmon:23:in `load'
        6: from /Users/sugy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/kanmon-0.6.0/exe/kanmon:6:in `<top (required)>'
        5: from /Users/sugy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
        4: from /Users/sugy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
        3: from /Users/sugy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/kanmon-0.6.0/lib/kanmon/cli.rb:72:in `invoke_command'
        2: from /Users/sugy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
        1: from /Users/sugy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
/Users/sugy/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/kanmon-0.6.0/lib/kanmon/cli.rb:54:in `version': uninitialized constant Kanmon::VERSION (NameError)
```