### PR TITLE
Retry exec command in kanmon.open to wait security group applied

### DIFF
--- a/lib/kanmon/cli.rb
+++ b/lib/kanmon/cli.rb
@@ -47,7 +47,10 @@ module Kanmon
     def exec(*args)
       @kanmon.open do
         command = Shellwords.join(args)
-        Process.wait spawn(command)
+        _, status = Process.wait2(spawn(command))
+        if status.to_i != 0
+          raise "Fail to exec command: #{command}"
+        end
       end
     end
 

--- a/lib/kanmon/server.rb
+++ b/lib/kanmon/server.rb
@@ -37,12 +37,18 @@ module Kanmon
     end
 
     def open
+      try = 0
       create_sg
       add_sg
 
       if block_given?
         begin
           yield
+        rescue => e
+          try += 1
+          puts "retry #{try} times..."
+          retry if try < 5
+          raise e
         ensure
           remove_sg
           delete_sg


### PR DESCRIPTION
If exec ssh when security group isn't applied yet, ssh command fail with error message ' Connection refused'.
So, I add to retry exec command in kanmon.open to wait security group applied.